### PR TITLE
[nemo-qml-plugin-contacts] Force the contacts backend selection in qt5

### DIFF
--- a/rpm/nemo-qml-plugin-contacts-qt5.spec
+++ b/rpm/nemo-qml-plugin-contacts-qt5.spec
@@ -9,7 +9,7 @@ Name:       nemo-qml-plugin-contacts-qt5
 # << macros
 
 Summary:    Nemo QML contacts plugin
-Version:    0.0.4
+Version:    0.0.5
 Release:    1
 Group:      System/Libraries
 License:    BSD

--- a/rpm/nemo-qml-plugin-contacts.spec
+++ b/rpm/nemo-qml-plugin-contacts.spec
@@ -9,7 +9,7 @@ Name:       nemo-qml-plugin-contacts
 # << macros
 
 Summary:    Nemo QML contacts plugin
-Version:    0.0.4
+Version:    0.0.5
 Release:    1
 Group:      System/Libraries
 License:    BSD

--- a/src/seasidecache.cpp
+++ b/src/seasidecache.cpp
@@ -107,6 +107,10 @@ QList<QChar> SeasideCache::allContactNameGroups = getAllContactNameGroups();
 
 static QString managerName()
 {
+#ifdef USING_QTPIM
+    // Temporary override until qtpim supports QTCONTACTS_MANAGER_OVERRIDE
+    return QStringLiteral("org.nemomobile.contacts.sqlite");
+#endif
     QByteArray environmentManager = qgetenv("NEMO_CONTACT_MANAGER");
     return !environmentManager.isEmpty()
             ? QString::fromLatin1(environmentManager, environmentManager.length())


### PR DESCRIPTION
qtpim does not yet support the QTCONTACTS_MANAGER_OVERRIDE mechanism
for selecting the default contacts backend.
