### PR TITLE
[nemo-qml-plugin-contacts] Depend on qtcontacts-sqlite-qt5

### DIFF
--- a/rpm/nemo-qml-plugin-contacts-qt5.spec
+++ b/rpm/nemo-qml-plugin-contacts-qt5.spec
@@ -9,7 +9,7 @@ Name:       nemo-qml-plugin-contacts-qt5
 # << macros
 
 Summary:    Nemo QML contacts plugin
-Version:    0.0.5
+Version:    0.0.6
 Release:    1
 Group:      System/Libraries
 License:    BSD
@@ -22,6 +22,7 @@ BuildRequires:  pkgconfig(Qt5Gui)
 BuildRequires:  pkgconfig(Qt5Contacts)
 BuildRequires:  pkgconfig(Qt5Versit)
 BuildRequires:  pkgconfig(mlite5)
+Requires: qtcontacts-sqlite-qt5
 
 %description
 %{summary}.

--- a/rpm/nemo-qml-plugin-contacts.spec
+++ b/rpm/nemo-qml-plugin-contacts.spec
@@ -9,7 +9,7 @@ Name:       nemo-qml-plugin-contacts
 # << macros
 
 Summary:    Nemo QML contacts plugin
-Version:    0.0.5
+Version:    0.0.6
 Release:    1
 Group:      System/Libraries
 License:    BSD


### PR DESCRIPTION
Currently, the only Qt5Contacts backend that will work correctly for
our purposes is qtcontacts-sqlite-qt5.
