### PR TITLE
[nemo-qml-plugin-contacts] Stop exporting SeasideProxyModel

### DIFF
--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -65,7 +65,6 @@ public:
         Q_ASSERT(uri == QLatin1String("org.nemomobile.contacts"));
 
         qmlRegisterType<SeasideFilteredModel>(uri, 1, 0, "PeopleModel");
-        qmlRegisterType<SeasideFilteredModel>(uri, 1, 0, "PeopleProxyModel");
         qmlRegisterType<SeasideNameGroupModel>(uri, 1, 0, "PeopleNameGroupModel");
         qmlRegisterType<SeasidePersonAttached>();
         qmlRegisterType<SeasidePerson>(uri, 1, 0, "Person");

--- a/src/seasidefilteredmodel.h
+++ b/src/seasidefilteredmodel.h
@@ -126,7 +126,7 @@ public:
     int rowCount(const QModelIndex &parent = QModelIndex()) const;
     QVariant data(const QModelIndex &index, int role) const;
 
-    // SeasideProxyModel compatibilty naming.
+    // Backward-compatibilty:
     Q_INVOKABLE void setFilter(FilterType type) { setFilterType(type); }
     Q_INVOKABLE void search(const QString &pattern) { setFilterPattern(pattern); }
 


### PR DESCRIPTION
No longer used by clients.
