### PR TITLE
[nemo-qml-plugin-contacts] Emit constituentsFetched immediately

### DIFF
--- a/src/seasideperson.cpp
+++ b/src/seasideperson.cpp
@@ -1002,7 +1002,12 @@ QString SeasidePerson::vCard() const
 
 void SeasidePerson::fetchConstituents()
 {
-    SeasideCache::fetchConstituents(contact());
+    if (SeasideCache::validId(mContact->id())) {
+        SeasideCache::fetchConstituents(contact());
+    } else {
+        // No constituents
+        QMetaObject::invokeMethod(this, "constituentsChanged", Qt::QueuedConnection);
+    }
 }
 
 void SeasidePerson::fetchMergeCandidates()


### PR DESCRIPTION
An invalid contact has no constituents, so don't try to fetch any.
