### PR TITLE
[nemo-qml-plugin-contacts] Filter contacts by address type without QCont...

### DIFF
--- a/rpm/nemo-qml-plugin-contacts-qt5.spec
+++ b/rpm/nemo-qml-plugin-contacts-qt5.spec
@@ -23,8 +23,8 @@ BuildRequires:  pkgconfig(Qt5Gui)
 BuildRequires:  pkgconfig(Qt5Contacts)
 BuildRequires:  pkgconfig(Qt5Versit)
 BuildRequires:  pkgconfig(Qt5Test)
-BuildRequires:  pkgconfig(qtcontacts-sqlite-qt5-extensions)
-BuildRequires:  pkgconfig(contactcache-qt5) >= 0.0.4
+BuildRequires:  pkgconfig(qtcontacts-sqlite-qt5-extensions) >= 0.1.1
+BuildRequires:  pkgconfig(contactcache-qt5) >= 0.0.5
 
 %description
 %{summary}.

--- a/rpm/nemo-qml-plugin-contacts-qt5.yaml
+++ b/rpm/nemo-qml-plugin-contacts-qt5.yaml
@@ -17,8 +17,8 @@ PkgConfigBR:
     - Qt5Contacts
     - Qt5Versit
     - Qt5Test
-    - qtcontacts-sqlite-qt5-extensions
-    - contactcache-qt5 >= 0.0.1
+    - qtcontacts-sqlite-qt5-extensions > 0.1.1
+    - contactcache-qt5 >= 0.0.5
 Requires:
     - qtcontacts-sqlite-qt5
 Files:

--- a/rpm/nemo-qml-plugin-contacts.spec
+++ b/rpm/nemo-qml-plugin-contacts.spec
@@ -20,8 +20,8 @@ BuildRequires:  pkgconfig(QtCore) >= 4.7.0
 BuildRequires:  pkgconfig(QtDeclarative)
 BuildRequires:  pkgconfig(QtGui)
 BuildRequires:  pkgconfig(QtContacts)
-BuildRequires:  pkgconfig(qtcontacts-sqlite-extensions)
-BuildRequires:  pkgconfig(contactcache) >= 0.0.4
+BuildRequires:  pkgconfig(qtcontacts-sqlite-extensions) >= 0.1.1
+BuildRequires:  pkgconfig(contactcache) >= 0.0.5
 Provides:   nemo-qml-plugins-contacts > 0.3.26
 Obsoletes:   nemo-qml-plugins-contacts <= 0.3.26
 

--- a/rpm/nemo-qml-plugin-contacts.yaml
+++ b/rpm/nemo-qml-plugin-contacts.yaml
@@ -15,8 +15,8 @@ PkgConfigBR:
     - QtDeclarative
     - QtGui
     - QtContacts
-    - qtcontacts-sqlite-extensions
-    - contactcache >= 0.0.1
+    - qtcontacts-sqlite-extensions >= 0.1.1
+    - contactcache >= 0.0.5
 Provides:
     - nemo-qml-plugins-contacts > 0.3.26
 Obsoletes:

--- a/src/seasidefilteredmodel.cpp
+++ b/src/seasidefilteredmodel.cpp
@@ -35,6 +35,7 @@
 #include <synchronizelists.h>
 
 #include <qtcontacts-extensions.h>
+#include <QContactStatusFlags>
 
 #include <QContactAvatar>
 #include <QContactEmailAddress>
@@ -244,9 +245,9 @@ bool SeasideFilteredModel::filterId(const ContactIdType &contactId) const
         return false;
 
     if (m_requiredProperty != NoPropertyRequired) {
-        if ((m_requiredProperty == AccountUriRequired && item->contact.detail<QContactOnlineAccount>().isEmpty()) ||
-            (m_requiredProperty == PhoneNumberRequired && item->contact.detail<QContactPhoneNumber>().isEmpty()) ||
-            (m_requiredProperty == EmailAddressRequired && item->contact.detail<QContactEmailAddress>().isEmpty())) {
+        if ((m_requiredProperty == AccountUriRequired && ((item->statusFlags & QContactStatusFlags::HasOnlineAccount) == 0)) ||
+            (m_requiredProperty == PhoneNumberRequired && ((item->statusFlags & QContactStatusFlags::HasPhoneNumber) == 0)) ||
+            (m_requiredProperty == EmailAddressRequired && ((item->statusFlags & QContactStatusFlags::HasEmailAddress) == 0))) {
             return false;
         }
     }

--- a/src/seasidenamegroupmodel.cpp
+++ b/src/seasidenamegroupmodel.cpp
@@ -31,6 +31,8 @@
 
 #include "seasidenamegroupmodel.h"
 
+#include <QContactStatusFlags>
+
 #include <QContactOnlineAccount>
 #include <QContactPhoneNumber>
 #include <QContactEmailAddress>
@@ -164,9 +166,9 @@ int SeasideNameGroupModel::countFilteredContacts(const QSet<quint32> &contactIds
             SeasideCache::CacheItem *item = SeasideCache::existingItem(iid);
             Q_ASSERT(item);
 
-            if ((m_requiredProperty == AccountUriRequired && !item->contact.detail<QContactOnlineAccount>().isEmpty()) ||
-                (m_requiredProperty == PhoneNumberRequired && !item->contact.detail<QContactPhoneNumber>().isEmpty()) ||
-                (m_requiredProperty == EmailAddressRequired && !item->contact.detail<QContactEmailAddress>().isEmpty())) {
+            if ((m_requiredProperty == AccountUriRequired && (item->statusFlags & QContactStatusFlags::HasOnlineAccount)) ||
+                (m_requiredProperty == PhoneNumberRequired && (item->statusFlags & QContactStatusFlags::HasPhoneNumber)) ||
+                (m_requiredProperty == EmailAddressRequired && (item->statusFlags & QContactStatusFlags::HasEmailAddress))) {
                 ++count;
             }
         }

--- a/tests/tst_seasidefilteredmodel/seasidecache.h
+++ b/tests/tst_seasidefilteredmodel/seasidecache.h
@@ -68,6 +68,7 @@ public:
         QContact contact;
         ItemData *itemData;
         ModelData *modelData;
+        quint64 statusFlags;
         ContactState contactState;
     };
 


### PR DESCRIPTION
...act data

Allow address type filtering to be performed without retrieving the
full QContact object.
