### PR TITLE
[nemo-qml-plugin-contacts] Handle setContactData in various states

### DIFF
--- a/src/seasideperson.cpp
+++ b/src/seasideperson.cpp
@@ -1014,6 +1014,27 @@ void SeasidePerson::ensureComplete()
     }
 }
 
+QVariant SeasidePerson::contactData() const
+{
+    return QVariant::fromValue(contact());
+}
+
+void SeasidePerson::setContactData(const QVariant &data)
+{
+    if (mAttachState == Unattached) {
+        delete mContact;
+    } else if (mAttachState == Listening) {
+        mItem->removeListener(this);
+        mItem = 0;
+    }
+
+    mContact = new QContact(data.value<QContact>());
+    mAttachState = Unattached;
+
+    // We don't know if this contact is complete or not - assume it isn't if it has an ID
+    mComplete = (id() == 0);
+}
+
 QString SeasidePerson::vCard() const
 {
     QVersitContactExporter exporter;

--- a/src/seasideperson.h
+++ b/src/seasideperson.h
@@ -282,8 +282,8 @@ public:
 
     Q_INVOKABLE void ensureComplete();
 
-    Q_INVOKABLE QVariant contactData() const { return QVariant::fromValue(contact()); }
-    Q_INVOKABLE void setContactData(const QVariant &data) { setContact(data.value<QContact>()); }
+    Q_INVOKABLE QVariant contactData() const;
+    Q_INVOKABLE void setContactData(const QVariant &data);
 
     Q_INVOKABLE QString vCard() const;
 


### PR DESCRIPTION
The correct handling for setContactData depends on whether the person
is linked to a contact in the cache or otherwise.
