### PR TITLE
[nemo-qml-plugin-contacts] SectionBucket role should use name group

### DIFF
--- a/src/seasidefilteredmodel.cpp
+++ b/src/seasidefilteredmodel.cpp
@@ -569,11 +569,7 @@ QVariant SeasideFilteredModel::data(SeasideCache::CacheItem *cacheItem, int role
             // If we have a person instance, prefer to use that
             return role == Qt::DisplayRole ? person->displayLabel() : person->sectionBucket();
         }
-
-        if (role == Qt::DisplayRole) {
-            return cacheItem->displayLabel;
-        }
-        return cacheItem->displayLabel.isEmpty() ? QChar() : cacheItem->displayLabel.at(0).toUpper();
+        return role == Qt::DisplayRole ? cacheItem->displayLabel : cacheItem->nameGroup;
     } else if (role == PersonRole) {
         // Avoid creating a Person instance for as long as possible.
         SeasideCache::ensureCompletion(cacheItem);

--- a/src/seasideperson.cpp
+++ b/src/seasideperson.cpp
@@ -216,14 +216,16 @@ QString SeasidePerson::displayLabel() const
 
 QString SeasidePerson::sectionBucket() const
 {
-    if (displayLabel().isEmpty())
-        return QString();
+    if (id() != 0) {
+        SeasideCache::CacheItem *cacheItem = SeasideCache::existingItem(mContact->id());
+        return SeasideCache::nameGroup(cacheItem);
+    }
 
-    // TODO: won't be at all correct for localisation
-    // for some locales (asian in particular), we may need multiple bytes - not
-    // just the first - also, we should use QLocale (or ICU) to uppercase, not
-    // QString, as QString uses C locale.
-    return displayLabel().at(0).toUpper();
+    if (!displayLabel().isEmpty()) {
+        return displayLabel().at(0).toUpper();
+    }
+
+    return QString();
 }
 
 QString SeasidePerson::companyName() const


### PR DESCRIPTION
The section bucket for categorizing contacts should be derived from
the name group to which they are allocated, which allows for groups
using non-latin characters.
