### PR TITLE
[nemo-qml-plugin-contacts] Adapt to changes in libcontacts for sort/disp...

### DIFF
--- a/src/seasidefilteredmodel.h
+++ b/src/seasidefilteredmodel.h
@@ -49,6 +49,7 @@ class SeasideFilteredModel : public SeasideCache::ListModel
     Q_PROPERTY(bool populated READ isPopulated NOTIFY populatedChanged)
     Q_PROPERTY(FilterType filterType READ filterType WRITE setFilterType NOTIFY filterTypeChanged)
     Q_PROPERTY(DisplayLabelOrder displayLabelOrder READ displayLabelOrder WRITE setDisplayLabelOrder NOTIFY displayLabelOrderChanged)
+    Q_PROPERTY(QString sortProperty READ sortProperty NOTIFY sortPropertyChanged)
     Q_PROPERTY(QString filterPattern READ filterPattern WRITE setFilterPattern NOTIFY filterPatternChanged)
     Q_PROPERTY(int requiredProperty READ requiredProperty WRITE setRequiredProperty NOTIFY requiredPropertyChanged)
     Q_PROPERTY(bool searchByFirstNameCharacter READ searchByFirstNameCharacter WRITE setSearchByFirstNameCharacter NOTIFY searchByFirstNameCharacterChanged)
@@ -89,7 +90,9 @@ public:
         EmailAddressesRole,
         AccountUrisRole,
         AccountPathsRole,
-        PersonRole
+        PersonRole,
+        PrimaryNameRole,
+        SecondaryNameRole
     };
 
     typedef SeasideCache::ContactIdType ContactIdType;
@@ -113,6 +116,8 @@ public:
 
     DisplayLabelOrder displayLabelOrder() const;
     void setDisplayLabelOrder(DisplayLabelOrder order);
+
+    QString sortProperty() const;
 
     Q_INVOKABLE QVariantMap get(int row) const;
     Q_INVOKABLE QVariant get(int row, int role) const;
@@ -163,6 +168,7 @@ public:
 
     void makePopulated();
     void updateDisplayLabelOrder();
+    void updateSortProperty();
 
 signals:
     void populatedChanged();
@@ -171,6 +177,7 @@ signals:
     void requiredPropertyChanged();
     void searchByFirstNameCharacterChanged();
     void displayLabelOrderChanged();
+    void sortPropertyChanged();
     void countChanged();
 
 private:

--- a/src/seasideperson.h
+++ b/src/seasideperson.h
@@ -172,6 +172,12 @@ public:
     Q_PROPERTY(QString displayLabel READ displayLabel NOTIFY displayLabelChanged)
     QString displayLabel() const;
 
+    Q_PROPERTY(QString primaryName READ primaryName NOTIFY primaryNameChanged)
+    QString primaryName() const;
+
+    Q_PROPERTY(QString secondaryName READ secondaryName NOTIFY secondaryNameChanged)
+    QString secondaryName() const;
+
     Q_PROPERTY(QString companyName READ companyName WRITE setCompanyName NOTIFY companyNameChanged)
     QString companyName() const;
     void setCompanyName(const QString &name);
@@ -327,6 +333,8 @@ signals:
     void lastNameChanged();
     void middleNameChanged();
     void displayLabelChanged();
+    void primaryNameChanged();
+    void secondaryNameChanged();
     void companyNameChanged();
     void nicknameChanged();
     void titleChanged();
@@ -361,6 +369,9 @@ public slots:
 
 private:
     void updateContactDetails(const QContact &oldContact);
+
+    QString getPrimaryName(const QContact &contact) const;
+    QString getSecondaryName(const QContact &contact) const;
 
     enum AttachState {
         Unattached = 0,

--- a/tests/tst_seasidefilteredmodel/seasidecache.cpp
+++ b/tests/tst_seasidefilteredmodel/seasidecache.cpp
@@ -358,21 +358,12 @@ QChar SeasideCache::determineNameGroup(const CacheItem *cacheItem)
     if (!cacheItem)
         return QChar();
 
+    const QContactName nameDetail = cacheItem->contact.detail<QContactName>();
+    const QString sort(sortProperty() == QString::fromLatin1("firstName") ? nameDetail.firstName() : nameDetail.lastName());
+
     QChar group;
-    QString first;
-    QString last;
-    QContactName nameDetail = cacheItem->contact.detail<QContactName>();
-    if (SeasideCache::displayLabelOrder() == FirstNameFirst) {
-        first = nameDetail.firstName();
-        last = nameDetail.lastName();
-    } else {
-        first = nameDetail.lastName();
-        last = nameDetail.firstName();
-    }
-    if (!first.isEmpty()) {
-        group = first[0].toUpper();
-    } else if (!last.isEmpty()) {
-        group = last[0].toUpper();
+    if (!sort.isEmpty()) {
+        group = sort[0].toUpper();
     } else if (!cacheItem->displayLabel.isEmpty()) {
         group = cacheItem->displayLabel[0].toUpper();
     }
@@ -498,6 +489,11 @@ QString SeasideCache::generateDisplayLabelFromNonNameDetails(const QContact &)
 SeasideCache::DisplayLabelOrder SeasideCache::displayLabelOrder()
 {
     return FirstNameFirst;
+}
+
+QString SeasideCache::sortProperty()
+{
+    return QString::fromLatin1("firstName");
 }
 
 void SeasideCache::populate(FilterType filterType)

--- a/tests/tst_seasidefilteredmodel/seasidecache.h
+++ b/tests/tst_seasidefilteredmodel/seasidecache.h
@@ -38,7 +38,7 @@ public:
     };
 
     enum DisplayLabelOrder {
-        FirstNameFirst,
+        FirstNameFirst = 0,
         LastNameFirst
     };
 
@@ -112,6 +112,7 @@ public:
 
         virtual void makePopulated() = 0;
         virtual void updateDisplayLabelOrder() = 0;
+        virtual void updateSortProperty() = 0;
     };
 
     struct ResolveListener
@@ -157,6 +158,7 @@ public:
     static void unregisterResolveListener(ResolveListener *listener);
 
     static DisplayLabelOrder displayLabelOrder();
+    static QString sortProperty();
 
     static int contactId(const QContact &contact);
 


### PR DESCRIPTION
...lay order

Add the primaryName and secondaryName readonly properties to SeasidePerson,
to be used where display order is required, rather than a formal
separation between first and last names.

Add the primaryName and secondaryName roles to the model, where they
should be used in preference to the existing firstName and lastName
roles, which are now deprecated.
