### PR TITLE
[nemo-qml-plugin-contacts] Improve avatar handling

### DIFF
--- a/rpm/nemo-qml-plugin-contacts-qt5.spec
+++ b/rpm/nemo-qml-plugin-contacts-qt5.spec
@@ -24,7 +24,7 @@ BuildRequires:  pkgconfig(Qt5Contacts)
 BuildRequires:  pkgconfig(Qt5Versit)
 BuildRequires:  pkgconfig(Qt5Test)
 BuildRequires:  pkgconfig(qtcontacts-sqlite-qt5-extensions) >= 0.1.1
-BuildRequires:  pkgconfig(contactcache-qt5) >= 0.0.24
+BuildRequires:  pkgconfig(contactcache-qt5) >= 0.0.26
 
 %description
 %{summary}.

--- a/src/seasidefilteredmodel.cpp
+++ b/src/seasidefilteredmodel.cpp
@@ -571,7 +571,7 @@ QVariant SeasideFilteredModel::data(SeasideCache::CacheItem *cacheItem, int role
     } else if (role == FavoriteRole) {
         return contact.detail<QContactFavorite>().isFavorite();
     } else if (role == AvatarRole || role == AvatarUrlRole) {
-        QUrl avatarUrl = contact.detail<QContactAvatar>().imageUrl();
+        QUrl avatarUrl = SeasideCache::filteredAvatarUrl(contact);
         if (role == AvatarUrlRole || !avatarUrl.isEmpty()) {
             return avatarUrl;
         }

--- a/src/seasideperson.h
+++ b/src/seasideperson.h
@@ -201,6 +201,7 @@ public:
     Q_PROPERTY(QUrl avatarUrl READ avatarUrl WRITE setAvatarUrl NOTIFY avatarUrlChanged)
     QUrl avatarUrl() const;
     void setAvatarUrl(QUrl avatarUrl);
+    Q_INVOKABLE QUrl filteredAvatarUrl(const QStringList &metadataFragments = QStringList()) const;
 
     Q_PROPERTY(QStringList phoneNumbers READ phoneNumbers WRITE setPhoneNumbers NOTIFY phoneNumbersChanged)
     QStringList phoneNumbers() const;

--- a/tests/tst_seasidefilteredmodel/seasidecache.cpp
+++ b/tests/tst_seasidefilteredmodel/seasidecache.cpp
@@ -452,6 +452,11 @@ QString SeasideCache::generateDisplayLabelFromNonNameDetails(const QContact &)
     return QString();
 }
 
+QUrl SeasideCache::filteredAvatarUrl(const QContact &, const QStringList &)
+{
+    return QUrl();
+}
+
 SeasideCache::DisplayLabelOrder SeasideCache::displayLabelOrder()
 {
     return FirstNameFirst;

--- a/tests/tst_seasidefilteredmodel/seasidecache.h
+++ b/tests/tst_seasidefilteredmodel/seasidecache.h
@@ -201,6 +201,7 @@ public:
 
     static QString generateDisplayLabel(const QContact &contact, DisplayLabelOrder order = FirstNameFirst);
     static QString generateDisplayLabelFromNonNameDetails(const QContact &contact);
+    static QUrl filteredAvatarUrl(const QContact &contact, const QStringList &metadataFragments = QStringList());
 
     void populate(FilterType filterType);
     void insert(FilterType filterType, int index, const QVector<ContactIdType> &ids);


### PR DESCRIPTION
A contact can have multiple avatars.  This change allows avatars
to be filtered based on image metadata (tag) and also on whether
the image is a local or remote file location.
