### PR TITLE
[nemo-qml-plugin-contacts] Prevent duplication of imported contacts

### DIFF
--- a/tools/vcardconverter/main.cpp
+++ b/tools/vcardconverter/main.cpp
@@ -37,10 +37,33 @@
 // Contacts
 #include <QContactDetailFilter>
 #include <QContactFetchHint>
-#include <QContactGuid>
 #include <QContactManager>
 #include <QContactSortOrder>
 #include <QContactSyncTarget>
+
+#include <QContactAddress>
+#include <QContactAnniversary>
+#include <QContactAvatar>
+#include <QContactBirthday>
+#include <QContactEmailAddress>
+#include <QContactGuid>
+#include <QContactHobby>
+#include <QContactName>
+#include <QContactNickname>
+#include <QContactNote>
+#include <QContactOnlineAccount>
+#include <QContactOrganization>
+#include <QContactPhoneNumber>
+#include <QContactRingtone>
+#include <QContactTag>
+#include <QContactUrl>
+
+#ifdef USING_QTPIM
+#include <QContactIdFilter>
+#include <QContactExtendedDetail>
+#else
+#include <QContactLocalIdFilter>
+#endif
 
 // Versit
 #include <QVersitContactExporter>
@@ -62,6 +85,17 @@ void invalidUsage(const QString &app)
     ::exit(1);
 }
 
+QContactFetchHint basicFetchHint()
+{
+    QContactFetchHint fetchHint;
+
+    fetchHint.setOptimizationHints(QContactFetchHint::NoRelationships |
+                                   QContactFetchHint::NoActionPreferences |
+                                   QContactFetchHint::NoBinaryBlobs);
+
+    return fetchHint;
+}
+
 QContactFilter localContactFilter()
 {
     // Contacts that are local to the device have sync target 'local' or 'was_local'
@@ -79,15 +113,163 @@ QContactFilter localContactFilter()
     return filterLocal | filterWasLocal;
 }
 
-QContactDetailFilter guidFilter()
+QString contactNameString(const QContact &contact)
 {
-    QContactDetailFilter filter;
+    QStringList details;
+    QContactName name(contact.detail<QContactName>());
+    details.append(name.prefix());
+    details.append(name.firstName());
+    details.append(name.middleName());
+    details.append(name.lastName());
+    details.append(name.suffix());
+    return details.join(QChar::fromLatin1('|'));
+}
+
+
+template<typename T, typename F>
+QVariant detailValue(const T &detail, F field)
+{
 #ifdef USING_QTPIM
-    filter.setDetailType(QContactGuid::Type, QContactGuid::FieldGuid);
+    return detail.value(field);
 #else
-    filter.setDetailDefinitionName(QContactGuid::DefinitionName, QContactGuid::FieldGuid);
+    return detail.variantValue(field);
 #endif
-    return filter;
+}
+
+#ifdef USING_QTPIM
+typedef QMap<int, QVariant> DetailMap;
+#else
+typedef QVariantMap DetailMap;
+#endif
+
+DetailMap detailValues(const QContactDetail &detail)
+{
+#ifdef USING_QTPIM
+    DetailMap rv(detail.values());
+#else
+    DetailMap rv(detail.variantValues());
+#endif
+    return rv;
+}
+
+static bool variantEqual(const QVariant &lhs, const QVariant &rhs)
+{
+#ifdef USING_QTPIM
+    // Work around incorrect result from QVariant::operator== when variants contain QList<int>
+    static const int QListIntType = QMetaType::type("QList<int>");
+
+    const int lhsType = lhs.userType();
+    if (lhsType != rhs.userType()) {
+        return false;
+    }
+
+    if (lhsType == QListIntType) {
+        return (lhs.value<QList<int> >() == rhs.value<QList<int> >());
+    }
+#endif
+    return (lhs == rhs);
+}
+
+static bool detailValuesSuperset(const QContactDetail &lhs, const QContactDetail &rhs)
+{
+    // True if all values in rhs are present in lhs
+    const DetailMap lhsValues(detailValues(lhs));
+    const DetailMap rhsValues(detailValues(rhs));
+
+    if (lhsValues.count() < rhsValues.count()) {
+        return false;
+    }
+
+    foreach (const DetailMap::key_type &key, rhsValues.keys()) {
+        if (!variantEqual(lhsValues[key], rhsValues[key])) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+// Override for QContactUrl because importer produces incorrectly typed URL field
+static bool detailValuesSuperset(const QContactUrl &lhs, const QContactUrl &rhs)
+{
+    const DetailMap lhsValues(detailValues(lhs));
+    const DetailMap rhsValues(detailValues(rhs));
+
+    if (lhsValues.count() < rhsValues.count()) {
+        return false;
+    }
+
+    foreach (const DetailMap::key_type &key, rhsValues.keys()) {
+        if (key == QContactUrl::FieldUrl) {
+            QVariant lhsVar(lhsValues[key]);
+            QVariant rhsVar(rhsValues[key]);
+            QUrl lhsUrl = (lhsVar.type() == QMetaType::QUrl) ? lhsVar.value<QUrl>() : QUrl(lhsVar.value<QString>());
+            QUrl rhsUrl = (rhsVar.type() == QMetaType::QUrl) ? rhsVar.value<QUrl>() : QUrl(rhsVar.value<QString>());
+            if (lhsUrl != rhsUrl) {
+                return false;
+            }
+        } else {
+            if (!variantEqual(lhsValues[key], rhsValues[key])) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+template<typename T>
+void updateExistingDetails(QContact *updateContact, const QContact &importedContact, bool singular = false)
+{
+    QList<T> existingDetails(updateContact->details<T>());
+    if (singular && !existingDetails.isEmpty())
+        return;
+
+    foreach (T detail, importedContact.details<T>()) {
+        // See if the contact already has a detail which is a superset of this one
+        bool found = false;
+        foreach (const T &existing, existingDetails) {
+            if (detailValuesSuperset(existing, detail)) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            updateContact->saveDetail(&detail);
+        }
+    }
+}
+
+void mergeIntoExistingContact(QContact *updateContact, const QContact &importedContact)
+{
+    // Update the existing contact with any details in the new import
+    updateExistingDetails<QContactAddress>(updateContact, importedContact);
+    updateExistingDetails<QContactAnniversary>(updateContact, importedContact);
+    updateExistingDetails<QContactAvatar>(updateContact, importedContact);
+    updateExistingDetails<QContactBirthday>(updateContact, importedContact, true);
+    updateExistingDetails<QContactEmailAddress>(updateContact, importedContact);
+    updateExistingDetails<QContactGuid>(updateContact, importedContact);
+    updateExistingDetails<QContactHobby>(updateContact, importedContact);
+    updateExistingDetails<QContactNickname>(updateContact, importedContact);
+    updateExistingDetails<QContactNote>(updateContact, importedContact);
+    updateExistingDetails<QContactOnlineAccount>(updateContact, importedContact);
+    updateExistingDetails<QContactOrganization>(updateContact, importedContact);
+    updateExistingDetails<QContactPhoneNumber>(updateContact, importedContact);
+    updateExistingDetails<QContactRingtone>(updateContact, importedContact);
+    updateExistingDetails<QContactTag>(updateContact, importedContact);
+    updateExistingDetails<QContactUrl>(updateContact, importedContact);
+#ifdef USING_QTPIM
+    updateExistingDetails<QContactExtendedDetail>(updateContact, importedContact);
+#endif
+}
+
+void updateExistingContact(QContact *updateContact, const QContact &contact)
+{
+    // Replace the imported contact with the existing version
+    QContact importedContact(*updateContact);
+    *updateContact = contact;
+
+    mergeIntoExistingContact(updateContact, importedContact);
 }
 
 }
@@ -136,6 +318,7 @@ int main(int argc, char **argv)
         QVersitContactImporter importer;
         importer.setPropertyHandler(&photoHandler);
 
+        // Read the contacts from the VCF
         QVersitReader reader(&vcf);
         reader.startReading();
         reader.waitForFinished();
@@ -143,36 +326,141 @@ int main(int argc, char **argv)
         importer.importDocuments(reader.results());
         QList<QContact> importedContacts(importer.contacts());
 
-        // Find all GUIDs for local contacts
-        QContactFetchHint fetchHint;
-#ifdef USING_QTPIM
-        fetchHint.setDetailTypesHint(QList<QContactDetail::DetailType>() << QContactGuid::Type);
-#else
-        fetchHint.setDetailDefinitionsHint(QStringList() << QContactGuid::DefinitionName);
-#endif
+        QHash<QString, QList<QContact>::iterator> importGuids;
+        QHash<QString, QList<QContact>::iterator> importNames;
 
-        QSet<QString> existingGuids;
-        QContactFilter filter(localContactFilter() & guidFilter());
-        foreach (const QContact &contact, mgr.contacts(filter, QList<QContactSortOrder>(), fetchHint)) {
-            existingGuids.insert(contact.detail<QContactGuid>().guid());
-        }
-
-        int existingCount = 0;
-
-        // Ignore any contacts we already have (by GUID)
+        // Merge any duplicates in the import list
         QList<QContact>::iterator it = importedContacts.begin();
         while (it != importedContacts.end()) {
             const QString guid = (*it).detail<QContactGuid>().guid();
-            if (!guid.isEmpty() && existingGuids.contains(guid)) {
-                it = importedContacts.erase(it);
-                ++existingCount;
+            const QString name = contactNameString((*it));
+
+            QContact *previous = 0;
+            QHash<QString, QList<QContact>::iterator>::const_iterator git = importGuids.find(guid);
+            if (git != importGuids.end()) {
+                QContact &contact(*(git.value()));
+                previous = &contact;
             } else {
+                QHash<QString, QList<QContact>::iterator>::const_iterator nit = importNames.find(name);
+                if (nit != importNames.end()) {
+                    QContact &contact(*(nit.value()));
+                    previous = &contact;
+                }
+            }
+
+            if (previous) {
+                // Combine these dupliacte contacts
+                mergeIntoExistingContact(previous, *it);
+                it = importedContacts.erase(it);
+            } else {
+                if (!guid.isEmpty()) {
+                    importGuids.insert(guid, it);
+                }
+                if (!name.isEmpty()) {
+                    importNames.insert(name, it);
+                }
+
                 ++it;
             }
         }
 
+        // Find all names and GUIDs for local contacts that might match these contacts
+        QContactFetchHint fetchHint(basicFetchHint());
+#ifdef USING_QTPIM
+        fetchHint.setDetailTypesHint(QList<QContactDetail::DetailType>() << QContactName::Type << QContactGuid::Type);
+#else
+        fetchHint.setDetailDefinitionsHint(QStringList() << QContactName::DefinitionName << QContactGuid::DefinitionName);
+#endif
+
+        QHash<QString, QContactId> existingGuids;
+        QHash<QString, QContactId> existingNames;
+
+        foreach (const QContact &contact, mgr.contacts(localContactFilter(), QList<QContactSortOrder>(), fetchHint)) {
+            const QString guid = contact.detail<QContactGuid>().guid();
+            const QString name = contactNameString(contact);
+
+            if (!guid.isEmpty()) {
+                existingGuids.insert(guid, contact.id());
+            }
+            if (!name.isEmpty()) {
+                existingNames.insert(name, contact.id());
+            }
+        }
+
+        // Find any imported contacts that match contacts we already have
+        int newCount = 0;
+        QMap<QContactId, QList<QContact>::iterator> existingIds;
+        QList<QList<QContact>::iterator> duplicates;
+
+        QList<QContact>::iterator end = importedContacts.end();
+        for (it = importedContacts.begin(); it != end; ++it) {
+            const QString guid = (*it).detail<QContactGuid>().guid();
+
+            QContactId existingId;
+
+            bool existing = true;
+            QHash<QString, QContactId>::const_iterator git = existingGuids.find(guid);
+            if (git != existingGuids.end()) {
+                existingId = *git;
+            } else {
+                const QString name = contactNameString(*it);
+
+                QHash<QString, QContactId>::const_iterator nit = existingNames.find(name);
+                if (nit != existingNames.end()) {
+                    existingId = *nit;
+                } else {
+                    existing = false;
+                }
+            }
+
+            if (existing) {
+                QMap<QContactId, QList<QContact>::iterator>::iterator eit = existingIds.find(existingId);
+                if (eit == existingIds.end()) {
+                    existingIds.insert(existingId, it);
+                } else {
+                    // Combine these contacts with matching names
+                    QList<QContact>::iterator cit(*eit);
+                    mergeIntoExistingContact(&*cit, *it);
+
+                    duplicates.append(it);
+                }
+            } else {
+                ++newCount;
+            }
+        }
+
+        // Remove any duplicates we identified
+        while (!duplicates.isEmpty())
+            importedContacts.erase(duplicates.takeLast());
+
+        const int existingCount(existingIds.count());
+        if (existingCount > 0) {
+            // Retrieve all the contacts that we have matches for
+#ifdef USING_QTPIM
+            QContactIdFilter idFilter;
+            idFilter.setIds(existingIds.keys());
+#else
+            QContactLocalIdFilter idFilter;
+            QList<QContactLocalId> localIds;
+            foreach (const QContactId &id, existingIds.keys()) {
+                localids.append(id.toLocal());
+            }
+#endif
+            foreach (const QContact &contact, mgr.contacts(idFilter & localContactFilter(), QList<QContactSortOrder>(), basicFetchHint())) {
+                QMap<QContactId, QList<QContact>::iterator>::const_iterator it = existingIds.find(contact.id());
+                if (it != existingIds.end()) {
+                    // Update the existing version of the contact with any new details
+                    QList<QContact>::iterator cit(*it);
+                    QContact &importContact(*cit);
+                    updateExistingContact(&importContact, contact);
+                } else {
+                    qWarning() << "unable to update existing contact:" << contact.id();
+                }
+            }
+        }
+
         QString existingDesc(existingCount ? QString::fromLatin1(" (%1 already existing)").arg(existingCount) : QString());
-        qDebug("Importing %d contacts%s", importedContacts.count(), qPrintable(existingDesc));
+        qDebug("Importing %d new contacts%s", newCount, qPrintable(existingDesc));
 
         QMap<int, QContactManager::Error> errors;
         mgr.saveContacts(&importedContacts, &errors);


### PR DESCRIPTION
Rather than re-importing contacts in multiple imports, find matching
existing contacts by GUID or name, and add any missing details to those.
