### PR TITLE
[nemo-qml-plugin-contacts] Expand phone number details

### DIFF
--- a/src/seasideperson.h
+++ b/src/seasideperson.h
@@ -66,6 +66,9 @@ public:
 
     SeasidePerson *selfPerson() const;
 
+    Q_INVOKABLE QString normalizePhoneNumber(const QString &input);
+    Q_INVOKABLE QString minimizePhoneNumber(const QString &input);
+
 signals:
     // Not currently emitted:
     void selfPersonChanged();

--- a/tests/tst_seasidefilteredmodel/seasidecache.cpp
+++ b/tests/tst_seasidefilteredmodel/seasidecache.cpp
@@ -473,6 +473,16 @@ QUrl SeasideCache::filteredAvatarUrl(const QContact &contact, const QStringList 
     return QUrl();
 }
 
+QString SeasideCache::normalizePhoneNumber(const QString &input)
+{
+    return input;
+}
+
+QString SeasideCache::minimizePhoneNumber(const QString &input)
+{
+    return input;
+}
+
 SeasideCache::DisplayLabelOrder SeasideCache::displayLabelOrder()
 {
     return FirstNameFirst;

--- a/tests/tst_seasidefilteredmodel/seasidecache.h
+++ b/tests/tst_seasidefilteredmodel/seasidecache.h
@@ -205,6 +205,9 @@ public:
     static QString generateDisplayLabelFromNonNameDetails(const QContact &contact);
     static QUrl filteredAvatarUrl(const QContact &contact, const QStringList &metadataFragments = QStringList());
 
+    static QString normalizePhoneNumber(const QString &input);
+    static QString minimizePhoneNumber(const QString &input);
+
     void populate(FilterType filterType);
     void insert(FilterType filterType, int index, const QList<quint32> &ids);
     void remove(FilterType filterType, int index, int count);


### PR DESCRIPTION
Allow clients to access the normalized and minimized forms of phone numbers.
