### PR TITLE
nemo-qml-plugin-contacts] Only contacts with valid IM accounts pass filtering

### DIFF
--- a/src/seasidefilteredmodel.cpp
+++ b/src/seasidefilteredmodel.cpp
@@ -412,7 +412,7 @@ bool SeasideFilteredModel::filterId(quint32 iid) const
         return false;
 
     if (m_requiredProperty != NoPropertyRequired) {
-        bool haveMatch = (m_requiredProperty & AccountUriRequired) && (item->statusFlags & QContactStatusFlags::HasOnlineAccount);
+        bool haveMatch = (m_requiredProperty & AccountUriRequired) && (item->statusFlags & SeasideCache::HasValidOnlineAccount);
         haveMatch |= (m_requiredProperty & PhoneNumberRequired) && (item->statusFlags & QContactStatusFlags::HasPhoneNumber);
         haveMatch |= (m_requiredProperty & EmailAddressRequired) && (item->statusFlags & QContactStatusFlags::HasEmailAddress);
         if (!haveMatch)

--- a/tests/tst_seasidefilteredmodel/seasidecache.h
+++ b/tests/tst_seasidefilteredmodel/seasidecache.h
@@ -48,6 +48,10 @@ public:
         ContactComplete
     };
 
+    enum {
+        HasValidOnlineAccount = (QContactStatusFlags::IsOnline << 1)
+    };
+
     struct ItemData
     {
         virtual ~ItemData() {}


### PR DESCRIPTION
When requiredProperty specifies IM accounts, only contacts possessing valid IM accounts (those linked to valid telepathy accounts) should be included in the filtered model.

Adds one commit on top of: https://github.com/nemomobile/nemo-qml-plugin-contacts/pull/81
Depends on: https://github.com/nemomobile/libcontacts/pull/62
