### PR TITLE
[nemo-qml-plugin-contacts] Allow properties to be specified for searchability

### DIFF
--- a/src/seasidefilteredmodel.cpp
+++ b/src/seasidefilteredmodel.cpp
@@ -250,8 +250,8 @@ SeasideFilteredModel::SeasideFilteredModel(QObject *parent)
     , m_filterUpdateIndex(-1)
     , m_filterType(FilterAll)
     , m_effectiveFilterType(FilterAll)
-    , m_fetchTypes(SeasideCache::FetchNone)
     , m_requiredProperty(NoPropertyRequired)
+    , m_searchableProperty(NoPropertySearchable)
     , m_searchByFirstNameCharacter(false)
     , m_lastItem(0)
 {
@@ -387,6 +387,21 @@ int SeasideFilteredModel::requiredProperty() const
 void SeasideFilteredModel::setRequiredProperty(int type)
 {
     updateFilters(m_filterPattern, type);
+}
+
+int SeasideFilteredModel::searchableProperty() const
+{
+    return m_searchableProperty;
+}
+
+void SeasideFilteredModel::setSearchableProperty(int type)
+{
+    if (m_searchableProperty != type) {
+        m_searchableProperty = type;
+
+        updateRegistration();
+        emit searchablePropertyChanged();
+    }
 }
 
 bool SeasideFilteredModel::searchByFirstNameCharacter() const
@@ -864,8 +879,6 @@ void SeasideFilteredModel::updateFilters(const QString &pattern, int property)
         changedProperty = true;
 
         // Update our registration to include the data type we need
-        m_fetchTypes = static_cast<SeasideCache::FetchDataType>(m_requiredProperty);
-
         updateRegistration();
     }
 
@@ -926,7 +939,9 @@ void SeasideFilteredModel::updateFilters(const QString &pattern, int property)
 
 void SeasideFilteredModel::updateRegistration()
 {
-    SeasideCache::registerModel(this, static_cast<SeasideCache::FilterType>(m_effectiveFilterType), m_fetchTypes);
+    const SeasideCache::FetchDataType requiredTypes(static_cast<SeasideCache::FetchDataType>(m_requiredProperty));
+    const SeasideCache::FetchDataType extraTypes(static_cast<SeasideCache::FetchDataType>(m_searchableProperty));
+    SeasideCache::registerModel(this, static_cast<SeasideCache::FilterType>(m_effectiveFilterType), requiredTypes, extraTypes);
 }
 
 void SeasideFilteredModel::invalidateRows(int begin, int count, bool filteredIndex, bool removeFromModel)

--- a/src/seasidefilteredmodel.h
+++ b/src/seasidefilteredmodel.h
@@ -52,9 +52,10 @@ class SeasideFilteredModel : public SeasideCache::ListModel
     Q_PROPERTY(QString groupProperty READ groupProperty NOTIFY groupPropertyChanged)
     Q_PROPERTY(QString filterPattern READ filterPattern WRITE setFilterPattern NOTIFY filterPatternChanged)
     Q_PROPERTY(int requiredProperty READ requiredProperty WRITE setRequiredProperty NOTIFY requiredPropertyChanged)
+    Q_PROPERTY(int searchableProperty READ searchableProperty WRITE setSearchableProperty NOTIFY searchablePropertyChanged)
     Q_PROPERTY(bool searchByFirstNameCharacter READ searchByFirstNameCharacter WRITE setSearchByFirstNameCharacter NOTIFY searchByFirstNameCharacterChanged)
     Q_PROPERTY(int count READ rowCount NOTIFY countChanged)
-    Q_ENUMS(FilterType RequiredPropertyType DisplayLabelOrder)
+    Q_ENUMS(FilterType RequiredPropertyType SearchablePropertyType DisplayLabelOrder)
 
 public:
     enum FilterType {
@@ -70,6 +71,14 @@ public:
         AccountUriRequired = SeasideCache::FetchAccountUri,
         PhoneNumberRequired = SeasideCache::FetchPhoneNumber,
         EmailAddressRequired = SeasideCache::FetchEmailAddress
+    };
+
+    enum SearchablePropertyType {
+        NoPropertySearchable = 0,
+        AccountUriSearchable = SeasideCache::FetchAccountUri,
+        PhoneNumberSearchable = SeasideCache::FetchPhoneNumber,
+        EmailAddressSearchable = SeasideCache::FetchEmailAddress,
+        OrganizationSearchable = SeasideCache::FetchOrganization
     };
 
     enum DisplayLabelOrder {
@@ -113,6 +122,9 @@ public:
 
     int requiredProperty() const;
     void setRequiredProperty(int type);
+
+    int searchableProperty() const;
+    void setSearchableProperty(int type);
 
     bool searchByFirstNameCharacter() const;
     void setSearchByFirstNameCharacter(bool searchByFirstNameCharacter);
@@ -182,6 +194,7 @@ signals:
     void filterTypeChanged();
     void filterPatternChanged();
     void requiredPropertyChanged();
+    void searchablePropertyChanged();
     void searchByFirstNameCharacterChanged();
     void displayLabelOrderChanged();
     void sortPropertyChanged();
@@ -218,8 +231,8 @@ private:
     int m_filterUpdateIndex;
     FilterType m_filterType;
     FilterType m_effectiveFilterType;
-    SeasideCache::FetchDataType m_fetchTypes;
     int m_requiredProperty;
+    int m_searchableProperty;
     bool m_searchByFirstNameCharacter;
 
     mutable SeasideCache::CacheItem *m_lastItem;

--- a/tests/tst_seasidefilteredmodel/seasidecache.cpp
+++ b/tests/tst_seasidefilteredmodel/seasidecache.cpp
@@ -225,7 +225,7 @@ SeasideCache::~SeasideCache()
     instancePtr = 0;
 }
 
-void SeasideCache::registerModel(ListModel *model, FilterType type, FetchDataType)
+void SeasideCache::registerModel(ListModel *model, FilterType type, FetchDataType, FetchDataType)
 {
     for (int i = 0; i < FilterTypesCount; ++i)
         instancePtr->m_models[i] = 0;

--- a/tests/tst_seasidefilteredmodel/seasidecache.h
+++ b/tests/tst_seasidefilteredmodel/seasidecache.h
@@ -33,7 +33,12 @@ public:
         FetchNone = 0,
         FetchAccountUri = (1 << 0),
         FetchPhoneNumber = (1 << 1),
-        FetchEmailAddress = (1 << 2)
+        FetchEmailAddress = (1 << 2),
+        FetchOrganization = (1 << 3),
+        FetchTypesMask = (FetchAccountUri |
+                          FetchPhoneNumber |
+                          FetchEmailAddress |
+                          FetchOrganization)
     };
 
     enum DisplayLabelOrder {
@@ -150,7 +155,7 @@ public:
     SeasideCache();
     ~SeasideCache();
 
-    static void registerModel(ListModel *model, FilterType type, FetchDataType extraData = FetchNone);
+    static void registerModel(ListModel *model, FilterType type, FetchDataType requiredTypes = FetchNone, FetchDataType extraTypes = FetchNone);
     static void unregisterModel(ListModel *model);
 
     static void registerUser(QObject *user);


### PR DESCRIPTION
A model can now specify properties that should be loaded asynchronously to facilitate searching.

Depends on: https://github.com/nemomobile/libcontacts/pull/70
