### PR TITLE
[nemo-qml-plugin-contacts] Adapt to libcontacts change

### DIFF
--- a/src/seasideperson.cpp
+++ b/src/seasideperson.cpp
@@ -1993,8 +1993,8 @@ QVariantList SeasidePerson::removeDuplicatePhoneNumbers(const QVariantList &phon
                 bool append(false);
 
                 const QChar plus(QChar::fromLatin1('+'));
-                if (normalized[0] == plus) {
-                    if (priorNormalized[0] == plus) {
+                if (normalized.length() && normalized[0] == plus) {
+                    if (priorNormalized.length() && priorNormalized[0] == plus) {
                         // Prefer the longer normalized form, or the longer unnormalized form
                         // if the normalized forms are equal
                         replace = (normalized.length() > priorNormalized.length() ||
@@ -2011,7 +2011,7 @@ QVariantList SeasidePerson::removeDuplicatePhoneNumbers(const QVariantList &phon
                     if (normalized.length() > priorNormalized.length() ||
                         (normalized.length() == priorNormalized.length() &&
                          number.length() > priorNumber.length())) {
-                        if (priorNormalized[0] == plus) {
+                        if (priorNormalized.length() && priorNormalized[0] == plus) {
                             append = true;
                         } else {
                             replace = true;

--- a/tests/tst_seasidefilteredmodel/seasidecache.cpp
+++ b/tests/tst_seasidefilteredmodel/seasidecache.cpp
@@ -426,12 +426,12 @@ QUrl SeasideCache::filteredAvatarUrl(const QContact &contact, const QStringList 
     return QUrl();
 }
 
-QString SeasideCache::normalizePhoneNumber(const QString &input)
+QString SeasideCache::normalizePhoneNumber(const QString &input, bool)
 {
     return input;
 }
 
-QString SeasideCache::minimizePhoneNumber(const QString &input)
+QString SeasideCache::minimizePhoneNumber(const QString &input, bool)
 {
     return input;
 }

--- a/tests/tst_seasidefilteredmodel/seasidecache.h
+++ b/tests/tst_seasidefilteredmodel/seasidecache.h
@@ -205,8 +205,8 @@ public:
     static QString generateDisplayLabelFromNonNameDetails(const QContact &contact);
     static QUrl filteredAvatarUrl(const QContact &contact, const QStringList &metadataFragments = QStringList());
 
-    static QString normalizePhoneNumber(const QString &input);
-    static QString minimizePhoneNumber(const QString &input);
+    static QString normalizePhoneNumber(const QString &input, bool validate = false);
+    static QString minimizePhoneNumber(const QString &input, bool validate = false);
 
     void populate(FilterType filterType);
     void insert(FilterType filterType, int index, const QList<quint32> &ids);


### PR DESCRIPTION
Also, protect invalid access to normalized phone numbers that may not
contain any data.

Depends on: https://github.com/nemomobile/libcontacts/pull/76
