### PR TITLE
[nemo-qml-plugin-contacts] Report 'enabled' status of IM account

### DIFF
--- a/src/seasideperson.cpp
+++ b/src/seasideperson.cpp
@@ -1530,6 +1530,7 @@ const QString accountDetailServiceProvider(QString::fromLatin1("serviceProvider"
 const QString accountDetailServiceProviderDisplayName(QString::fromLatin1("serviceProviderDisplayName"));
 const QString accountDetailPresenceState(QString::fromLatin1("presenceState"));
 const QString accountDetailPresenceMessage(QString::fromLatin1("presenceMessage"));
+const QString accountDetailEnabled(QString::fromLatin1("enabled"));
 
 template<typename ListType>
 typename ListType::value_type linkedDetail(const ListType &details, const QString &uri)
@@ -1561,6 +1562,7 @@ QVariantList SeasidePerson::accountDetails(const QContact &contact)
         item.insert(accountDetailIconPath, detail.value(QContactOnlineAccount__FieldAccountIconPath).toString());
         item.insert(accountDetailServiceProvider, detail.value(QContactOnlineAccount::FieldServiceProvider).toString());
         item.insert(accountDetailServiceProviderDisplayName, detail.value(QContactOnlineAccount__FieldServiceProviderDisplayName).toString());
+        item.insert(accountDetailEnabled, detail.value(QContactOnlineAccount__FieldEnabled).toBool());
 
         QVariant state;
         QVariant message;
@@ -1643,6 +1645,8 @@ void SeasidePerson::setAccountDetails(const QVariantList &accountDetails)
 
         const QVariant serviceProviderDisplayNameValue = detail[accountDetailServiceProviderDisplayName];
         updated.setValue(QContactOnlineAccount__FieldServiceProviderDisplayName, serviceProviderDisplayNameValue.value<QString>());
+
+        // Enabled is read-only; ignore update value
 
         const QVariant subTypesValue = detail[detailSubTypes];
         ::setOnlineAccountSubTypes(updated, subTypesValue.value<QVariantList>());


### PR DESCRIPTION
An IM account is disabled if the telepathy that implements its transport is not enabled.
