### PR TITLE
[nemo-qml-plugin-contacts] Expand organizational fields

### DIFF
--- a/src/seasideperson.cpp
+++ b/src/seasideperson.cpp
@@ -335,15 +335,48 @@ void SeasidePerson::setCompanyName(const QString &name)
 QString SeasidePerson::title() const
 {
     QContactOrganization company = mContact->detail<QContactOrganization>();
+    return company.title();
+}
+
+void SeasidePerson::setTitle(const QString &title)
+{
+    QContactOrganization companyDetail = mContact->detail<QContactOrganization>();
+    companyDetail.setTitle(title);
+    mContact->saveDetail(&companyDetail);
+    emit titleChanged();
+}
+
+QString SeasidePerson::role() const
+{
+    QContactOrganization company = mContact->detail<QContactOrganization>();
     return company.role();
 }
 
-void SeasidePerson::setTitle(const QString &role)
+void SeasidePerson::setRole(const QString &role)
 {
     QContactOrganization companyDetail = mContact->detail<QContactOrganization>();
     companyDetail.setRole(role);
     mContact->saveDetail(&companyDetail);
-    emit titleChanged();
+    emit roleChanged();
+}
+
+QString SeasidePerson::department() const
+{
+    QContactOrganization company = mContact->detail<QContactOrganization>();
+    return company.department().join(QString::fromLatin1("; "));
+}
+
+void SeasidePerson::setDepartment(const QString &department)
+{
+    QStringList dept;
+    foreach (const QString &field, department.split(QChar::fromLatin1(';'), QString::SkipEmptyParts)) {
+        dept.append(field.trimmed());
+    }
+
+    QContactOrganization companyDetail = mContact->detail<QContactOrganization>();
+    companyDetail.setDepartment(dept);
+    mContact->saveDetail(&companyDetail);
+    emit departmentChanged();
 }
 
 bool SeasidePerson::favorite() const
@@ -1733,8 +1766,14 @@ void SeasidePerson::updateContactDetails(const QContact &oldContact)
     if (oldCompany.name() != newCompany.name())
         emitChangeSignal(&SeasidePerson::companyNameChanged);
 
-    if (oldCompany.role() != newCompany.role())
+    if (oldCompany.title() != newCompany.title())
         emitChangeSignal(&SeasidePerson::titleChanged);
+
+    if (oldCompany.role() != newCompany.role())
+        emitChangeSignal(&SeasidePerson::roleChanged);
+
+    if (oldCompany.department() != newCompany.department())
+        emitChangeSignal(&SeasidePerson::departmentChanged);
 
     QContactFavorite oldFavorite = oldContact.detail<QContactFavorite>();
     QContactFavorite newFavorite = mContact->detail<QContactFavorite>();
@@ -1812,6 +1851,8 @@ void SeasidePerson::emitChangeSignals()
     emitChangeSignal(&SeasidePerson::middleNameChanged);
     emitChangeSignal(&SeasidePerson::companyNameChanged);
     emitChangeSignal(&SeasidePerson::titleChanged);
+    emitChangeSignal(&SeasidePerson::roleChanged);
+    emitChangeSignal(&SeasidePerson::departmentChanged);
     emitChangeSignal(&SeasidePerson::favoriteChanged);
     emitChangeSignal(&SeasidePerson::avatarUrlChanged);
     emitChangeSignal(&SeasidePerson::avatarPathChanged);

--- a/src/seasideperson.h
+++ b/src/seasideperson.h
@@ -100,6 +100,8 @@ public:
         SuffixType,
         CompanyType,
         TitleType,
+        RoleType,
+        DepartmentType,
         NicknameType,
         PhoneNumberType,
         EmailAddressType,
@@ -220,7 +222,15 @@ public:
 
     Q_PROPERTY(QString title READ title WRITE setTitle NOTIFY titleChanged)
     QString title() const;
-    void setTitle(const QString &name);
+    void setTitle(const QString &title);
+
+    Q_PROPERTY(QString role READ role WRITE setRole NOTIFY roleChanged)
+    QString role() const;
+    void setRole(const QString &role);
+
+    Q_PROPERTY(QString department READ department WRITE setDepartment NOTIFY departmentChanged)
+    QString department() const;
+    void setDepartment(const QString &department);
 
     Q_PROPERTY(bool favorite READ favorite WRITE setFavorite NOTIFY favoriteChanged)
     bool favorite() const;
@@ -351,6 +361,8 @@ signals:
     void secondaryNameChanged();
     void companyNameChanged();
     void titleChanged();
+    void roleChanged();
+    void departmentChanged();
     void favoriteChanged();
     void avatarPathChanged();
     void avatarUrlChanged();


### PR DESCRIPTION
We were previously confusing the 'role' and 'title' fields of a contact's organizational details.  Also, expose the department field, which is commonly used.
