### PR TITLE
[nemo-qml-plugin-contacts] Use vCard 3.0 when exporting contacts

### DIFF
--- a/src/seasideperson.cpp
+++ b/src/seasideperson.cpp
@@ -1943,7 +1943,7 @@ void SeasidePerson::resetContactData()
 QString SeasidePerson::vCard() const
 {
     QVersitContactExporter exporter;
-    if (!exporter.exportContacts(QList<QContact>() << *mContact, QVersitDocument::VCard21Type)) {
+    if (!exporter.exportContacts(QList<QContact>() << *mContact)) {
         qWarning() << Q_FUNC_INFO << "Failed to create vCard: " << exporter.errorMap();
         return QString();
     }


### PR DESCRIPTION
vCard 3.0 was defined in 1998 and has much saner encoding behavior. Using 2.1 may be causing compatibility problems with some devices.

The other code I could find using QVersitContactExporter is using the default of 3.0 as well.