### PR TITLE
[nemo-qml-plugin-contacts] Default display label order should match configuration

### DIFF
--- a/src/seasideperson.h
+++ b/src/seasideperson.h
@@ -382,7 +382,7 @@ signals:
     void dataChanged();
 
 public slots:
-    void recalculateDisplayLabel(SeasideCache::DisplayLabelOrder order = SeasideCache::FirstNameFirst) const;
+    void recalculateDisplayLabel(SeasideCache::DisplayLabelOrder order = SeasideCache::displayLabelOrder()) const;
 
 private:
     void updateContactDetails(const QContact &oldContact);


### PR DESCRIPTION
When generating the display label for a contact, if the required order
of first and last name is not specified, the default should be to
follow the ordering configured by the user.

Redirect of https://github.com/nemomobile/nemo-qml-plugin-contacts/pull/104 targeted to update6 branch.
