### PR TITLE
Fix crash if invalid row given. Fixes #113.

### DIFF
--- a/src/seasidefilteredmodel.cpp
+++ b/src/seasidefilteredmodel.cpp
@@ -700,7 +700,10 @@ bool SeasideFilteredModel::savePerson(SeasidePerson *person)
 
 SeasidePerson *SeasideFilteredModel::personByRow(int row) const
 {
-    return personFromItem(SeasideCache::itemById(m_contactIds->at(row)));
+    if(row < 0 || row >= m_allContactIds->size()) {
+        return NULL;
+    }
+    return personFromItem(SeasideCache::itemById(m_allContactIds->at(row)));
 }
 
 SeasidePerson *SeasideFilteredModel::personById(int id) const


### PR DESCRIPTION
Return null instead of crashing if row is invalid.
